### PR TITLE
Add postman collection for demo

### DIFF
--- a/examples/petstore-chi/_postman/Demo Collection.postman_collection.json
+++ b/examples/petstore-chi/_postman/Demo Collection.postman_collection.json
@@ -215,9 +215,7 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"var headerValue = pm.response.json().token",
-									"console.log(headerValue)",
-									"pm.collectionVariables.set(\"bearerToken\", headerValue)"
+									"pm.collectionVariables.set(\"bearerToken\", pm.response.json().token)"
 								],
 								"type": "text/javascript"
 							}


### PR DESCRIPTION
This PR adds the postman collection used for demos to the `petstore-chi` example to a `_postman` directory.