### PR TITLE
Make appspec optional

### DIFF
--- a/middlewares/http/middleware.go
+++ b/middlewares/http/middleware.go
@@ -21,19 +21,22 @@ import (
 func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, error) {
 	options.setDefaults() // Fill in any defaults where apropriate
 
-	// Load in our appspec, validate it & create a router from it.
-	loader := &openapi3.Loader{Context: context.Background(), IsExternalRefsAllowed: true}
-	doc, err := loader.LoadFromFile(options.OpenapiSpecPath)
-	if err != nil {
-		return nil, ErrorInvalidConfiguration{err}
-	}
-	err = doc.Validate(context.Background())
-	if err != nil {
-		return nil, ErrorAppspecInvalid{err}
-	}
-	router, err := gorillamux.NewRouter(doc)
-	if err != nil {
-		return nil, err
+	// Load in our appspec, validate it & create a router from it if we have an appspec to load
+	var router routers.Router
+	if options.OpenapiSpecPath != "" {
+		loader := &openapi3.Loader{Context: context.Background(), IsExternalRefsAllowed: true}
+		doc, err := loader.LoadFromFile(options.OpenapiSpecPath)
+		if err != nil {
+			return nil, ErrorInvalidConfiguration{err}
+		}
+		err = doc.Validate(context.Background())
+		if err != nil {
+			return nil, ErrorAppspecInvalid{err}
+		}
+		router, err = gorillamux.NewRouter(doc)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Register any custom body decoders
@@ -105,76 +108,80 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 			// Now we have the request body, we can fill it into our log entry
 			logEntry.Request.Body = string(requestBody)
 
-			// Check there's a corresponding route for this request
-			route, pathParams, err := router.FindRoute(r)
-			if err == routers.ErrMethodNotAllowed {
-				options.ErrCallback(ErrorUnsupportedMethod{r.URL.Path, r.Method}, localResponseWriter, r)
-				return
-			} else if err == routers.ErrPathNotFound {
-				options.ErrCallback(ErrorRouteNotFound{r.URL.Path}, localResponseWriter, r)
-				return
-			} else if err != nil {
-				options.ErrCallback(ErrorAtRequestUnspecified{err}, localResponseWriter, r)
-				return
-			}
-
-			// We now know the resource that was requested, so we can fill it into our log entry
-			logEntry.Request.Resource = route.Path
-
-			// If it hasn't been disabled, validate the request against the OpenAPI spec.
-			if !options.DisableRequestValidation {
-				requestValidationInput := &openapi3filter.RequestValidationInput{
-					Request:    r,
-					PathParams: pathParams,
-					Route:      route,
-					Options: &openapi3filter.Options{
-						AuthenticationFunc: func(ctx context.Context, ai *openapi3filter.AuthenticationInput) error {
-							authCallback, hasAuthCallback := options.AuthCallbacks[ai.SecuritySchemeName]
-							if !hasAuthCallback {
-								return ErrorAuthSchemeNotImplemented{ai.SecuritySchemeName}
-							}
-							return authCallback(ctx, ai)
-						},
-					},
-				}
-				err = openapi3filter.ValidateRequest(context.Background(), requestValidationInput)
-				if err != nil {
-					// If the err is an openapi3filter RequestError, we can extract more information from the err...
-					if err, isRequestErr := err.(*openapi3filter.RequestError); isRequestErr {
-						// TODO: Using strings.Contains is janky here and may break - should replace with something more reliable
-						// See the following open issue on the kin-openapi repo: https://github.com/getkin/kin-openapi/issues/477
-						// TODO: Open source contribution to kin-openapi?
-						if strings.Contains(err.Reason, "header Content-Type has unexpected value") {
-							options.ErrCallback(ErrorRequestContentTypeInvalid{r.Header.Get("Content-Type"), route.Path}, localResponseWriter, r)
-							return
-						}
-						if strings.Contains(err.Error(), "body has an error") {
-							options.ErrCallback(ErrorRequestBodyInvalid{err}, localResponseWriter, r)
-							return
-						}
-						if strings.Contains(err.Error(), "header has an error") {
-							options.ErrCallback(ErrorRequestHeadersInvalid{err}, localResponseWriter, r)
-							return
-						}
-						if strings.Contains(err.Error(), "query has an error") {
-							options.ErrCallback(ErrorRequestQueryParamsInvalid{err}, localResponseWriter, r)
-							return
-						}
-						if strings.Contains(err.Error(), "path has an error") {
-							options.ErrCallback(ErrorRequestPathParamsInvalid{err}, localResponseWriter, r)
-							return
-						}
-					}
-
-					// If the validation fails due to a security requirement, we pass a SecurityRequirementsError to the ErrCallback
-					if err, isSecurityErr := err.(*openapi3filter.SecurityRequirementsError); isSecurityErr {
-						options.ErrCallback(ErrorAuthNoMatchingScheme{err}, localResponseWriter, r)
-						return
-					}
-
-					// Else, we just use a non-specific ValidationError error
+			// Check there's a corresponding route for this request if we have a router
+			var route *routers.Route
+			var pathParams map[string]string
+			if router != nil {
+				route, pathParams, err = router.FindRoute(r)
+				if err == routers.ErrMethodNotAllowed {
+					options.ErrCallback(ErrorUnsupportedMethod{r.URL.Path, r.Method}, localResponseWriter, r)
+					return
+				} else if err == routers.ErrPathNotFound {
+					options.ErrCallback(ErrorRouteNotFound{r.URL.Path}, localResponseWriter, r)
+					return
+				} else if err != nil {
 					options.ErrCallback(ErrorAtRequestUnspecified{err}, localResponseWriter, r)
 					return
+				}
+
+				// We now know the resource that was requested, so we can fill it into our log entry
+				logEntry.Request.Resource = route.Path
+
+				// If it hasn't been disabled, validate the request against the OpenAPI spec.
+				if !options.DisableRequestValidation {
+					requestValidationInput := &openapi3filter.RequestValidationInput{
+						Request:    r,
+						PathParams: pathParams,
+						Route:      route,
+						Options: &openapi3filter.Options{
+							AuthenticationFunc: func(ctx context.Context, ai *openapi3filter.AuthenticationInput) error {
+								authCallback, hasAuthCallback := options.AuthCallbacks[ai.SecuritySchemeName]
+								if !hasAuthCallback {
+									return ErrorAuthSchemeNotImplemented{ai.SecuritySchemeName}
+								}
+								return authCallback(ctx, ai)
+							},
+						},
+					}
+					err = openapi3filter.ValidateRequest(context.Background(), requestValidationInput)
+					if err != nil {
+						// If the err is an openapi3filter RequestError, we can extract more information from the err...
+						if err, isRequestErr := err.(*openapi3filter.RequestError); isRequestErr {
+							// TODO: Using strings.Contains is janky here and may break - should replace with something more reliable
+							// See the following open issue on the kin-openapi repo: https://github.com/getkin/kin-openapi/issues/477
+							// TODO: Open source contribution to kin-openapi?
+							if strings.Contains(err.Reason, "header Content-Type has unexpected value") {
+								options.ErrCallback(ErrorRequestContentTypeInvalid{r.Header.Get("Content-Type"), route.Path}, localResponseWriter, r)
+								return
+							}
+							if strings.Contains(err.Error(), "body has an error") {
+								options.ErrCallback(ErrorRequestBodyInvalid{err}, localResponseWriter, r)
+								return
+							}
+							if strings.Contains(err.Error(), "header has an error") {
+								options.ErrCallback(ErrorRequestHeadersInvalid{err}, localResponseWriter, r)
+								return
+							}
+							if strings.Contains(err.Error(), "query has an error") {
+								options.ErrCallback(ErrorRequestQueryParamsInvalid{err}, localResponseWriter, r)
+								return
+							}
+							if strings.Contains(err.Error(), "path has an error") {
+								options.ErrCallback(ErrorRequestPathParamsInvalid{err}, localResponseWriter, r)
+								return
+							}
+						}
+
+						// If the validation fails due to a security requirement, we pass a SecurityRequirementsError to the ErrCallback
+						if err, isSecurityErr := err.(*openapi3filter.SecurityRequirementsError); isSecurityErr {
+							options.ErrCallback(ErrorAuthNoMatchingScheme{err}, localResponseWriter, r)
+							return
+						}
+
+						// Else, we just use a non-specific ValidationError error
+						options.ErrCallback(ErrorAtRequestUnspecified{err}, localResponseWriter, r)
+						return
+					}
 				}
 			}
 
@@ -184,8 +191,8 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 			next.ServeHTTP(chainResponseWriter, r)
 			logEntry.ExecutionTime = float64(time.Since(startTime).Milliseconds())
 
-			// If it hasn't been disabled, validate the response against the openapi spec
-			if !options.DisableResponseValidation {
+			// If it hasn't been disabled, and we were able to determine the route and path params, validate the response against the openapi spec
+			if !options.DisableResponseValidation && route != nil && pathParams != nil {
 				responseValidationInput := &openapi3filter.ResponseValidationInput{
 					RequestValidationInput: &openapi3filter.RequestValidationInput{
 						Request:    r,

--- a/middlewares/http/options.go
+++ b/middlewares/http/options.go
@@ -10,7 +10,7 @@ import (
 
 // Options is an options struct used when creating a Firetail middleware (GetMiddleware)
 type Options struct {
-	// SpecPath is the path at which your openapi spec can be found
+	// SpecPath is the path at which your openapi spec can be found. Supplying an empty string disables any validation.
 	OpenapiSpecPath string
 
 	// LogApiKey is the API key which will be used when sending logs to the Firetail logging API. This value should typically be loaded


### PR DESCRIPTION
This PR makes the appspec optional, so the go-lib can be used purely for logging purposes.