### PR TITLE
v0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,41 @@
 
 [![License](https://img.shields.io/pypi/l/firetail.svg)](https://github.com/FireTail-io/firetail-go-lib/blob/main/LICENSE.txt) [![Go Reference](https://pkg.go.dev/badge/github.com/FireTail-io/firetail-go-lib#section-readme.svg)](https://pkg.go.dev/github.com/FireTail-io/firetail-go-lib#section-readme) [![codecov](https://codecov.io/gh/FireTail-io/firetail-go-lib/branch/main/graph/badge.svg?token=QZX8OSE964)](https://codecov.io/gh/FireTail-io/firetail-go-lib)
 
-Want to use Firetail in your project? Good news! Soon, you'll be able to find packages containing middleware for various different frameworks in the [middlewares](./middlewares) directory, and examples of their use in [examples](./examples). :)
+Middlewares providing request and response validation against an OpenAPI spec at runtime, optionally integrating with the Firetail SaaS. Packages containing middleware for various different frameworks can be found in the [middlewares](./middlewares) directory, and examples of their use in [examples](./examples).
+
+
+
+## Getting Started
+
+### Middleware for `net/http`
+
+Get the middleware:
+
+```bash
+go get github.com/FireTail-io/firetail-go-lib/middlewares/http
+```
+
+Import it:
+
+```go
+import firetail "github.com/FireTail-io/firetail-go-lib/middlewares/http"
+```
+
+Create a middleware using `GetMiddleware`; see the `Options` struct for all the available configurations:
+
+```go
+firetailMiddleware, err := firetail.GetMiddleware(
+	&firetail.Options{
+		OpenapiSpecPath: path,
+		LogApiKey:       apiToken,
+	},
+)
+if err != nil {
+	// Handle the err...
+}
+```
+
+You will then have a `func(next http.Handler) http.Handler`, `firetailMiddleware`, which you can use to wrap a `http.Handler` just the same as with the middleware from [`net/http/middleware`](https://pkg.go.dev/go.ntrrg.dev/ntgo/net/http/middleware). This should also be suitable for [Chi](https://go-chi.io/#/pages/middleware).
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Firetail Go Library
 
-[![License](https://img.shields.io/pypi/l/firetail.svg)](https://github.com/FireTail-io/firetail-go-lib/blob/main/LICENSE.txt)
+[![License](https://img.shields.io/pypi/l/firetail.svg)](https://github.com/FireTail-io/firetail-go-lib/blob/main/LICENSE.txt) [![Go Reference](https://pkg.go.dev/badge/github.com/FireTail-io/firetail-go-lib#section-readme.svg)](https://pkg.go.dev/github.com/FireTail-io/firetail-go-lib#section-readme) [![codecov](https://codecov.io/gh/FireTail-io/firetail-go-lib/branch/main/graph/badge.svg?token=QZX8OSE964)](https://codecov.io/gh/FireTail-io/firetail-go-lib)
 
 Want to use Firetail in your project? Good news! Soon, you'll be able to find packages containing middleware for various different frameworks in the [middlewares](./middlewares) directory, and examples of their use in [examples](./examples). :)
 
 
 
 ## Tests
-
-[![codecov](https://codecov.io/gh/FireTail-io/firetail-go-lib/branch/main/graph/badge.svg?token=QZX8OSE964)](https://codecov.io/gh/FireTail-io/firetail-go-lib)
 
 Automated testing is setup with the `testing` package, using [github.com/stretchr/testify](https://pkg.go.dev/github.com/stretchr/testify) for shorthand assertions. You can run them with `go test`.
 

--- a/examples/minimal-chi/main.go
+++ b/examples/minimal-chi/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	firetailMiddleware, err := firetail.GetMiddleware(&firetail.Options{
 		OpenapiSpecPath: "app-spec.yaml",
-		LogApiKey:       os.Getenv("FIRETAIL_LOG_API_KEY"),
+		LogsApiToken:    os.Getenv("FIRETAIL_LOG_API_KEY"),
 	})
 	if err != nil {
 		panic(err)

--- a/examples/minimal-http/main.go
+++ b/examples/minimal-http/main.go
@@ -26,7 +26,7 @@ func main() {
 	// Get a firetail middleware
 	firetailMiddleware, err := firetail.GetMiddleware(&firetail.Options{
 		OpenapiSpecPath: "app-spec.yaml",
-		LogApiKey:       os.Getenv("FIRETAIL_LOG_API_KEY"),
+		LogsApiToken:    os.Getenv("FIRETAIL_LOG_API_KEY"),
 	})
 	if err != nil {
 		panic(err)

--- a/middlewares/http/middleware.go
+++ b/middlewares/http/middleware.go
@@ -49,8 +49,8 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 		MaxBatchSize:  1024 * 512,
 		MaxLogAge:     time.Minute,
 		BatchCallback: options.LogBatchCallback,
-		LogApiKey:     options.LogApiKey,
-		LogApiUrl:     options.LogApiUrl,
+		LogApiKey:     options.LogsApiToken,
+		LogApiUrl:     options.LogsApiUrl,
 	})
 
 	middleware := func(next http.Handler) http.Handler {

--- a/middlewares/http/middleware.go
+++ b/middlewares/http/middleware.go
@@ -21,19 +21,22 @@ import (
 func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, error) {
 	options.setDefaults() // Fill in any defaults where apropriate
 
-	// Load in our appspec, validate it & create a router from it.
-	loader := &openapi3.Loader{Context: context.Background(), IsExternalRefsAllowed: true}
-	doc, err := loader.LoadFromFile(options.OpenapiSpecPath)
-	if err != nil {
-		return nil, ErrorInvalidConfiguration{err}
-	}
-	err = doc.Validate(context.Background())
-	if err != nil {
-		return nil, ErrorAppspecInvalid{err}
-	}
-	router, err := gorillamux.NewRouter(doc)
-	if err != nil {
-		return nil, err
+	// Load in our appspec, validate it & create a router from it if we have an appspec to load
+	var router routers.Router
+	if options.OpenapiSpecPath != "" {
+		loader := &openapi3.Loader{Context: context.Background(), IsExternalRefsAllowed: true}
+		doc, err := loader.LoadFromFile(options.OpenapiSpecPath)
+		if err != nil {
+			return nil, ErrorInvalidConfiguration{err}
+		}
+		err = doc.Validate(context.Background())
+		if err != nil {
+			return nil, ErrorAppspecInvalid{err}
+		}
+		router, err = gorillamux.NewRouter(doc)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Register any custom body decoders
@@ -105,76 +108,80 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 			// Now we have the request body, we can fill it into our log entry
 			logEntry.Request.Body = string(requestBody)
 
-			// Check there's a corresponding route for this request
-			route, pathParams, err := router.FindRoute(r)
-			if err == routers.ErrMethodNotAllowed {
-				options.ErrCallback(ErrorUnsupportedMethod{r.URL.Path, r.Method}, localResponseWriter, r)
-				return
-			} else if err == routers.ErrPathNotFound {
-				options.ErrCallback(ErrorRouteNotFound{r.URL.Path}, localResponseWriter, r)
-				return
-			} else if err != nil {
-				options.ErrCallback(ErrorAtRequestUnspecified{err}, localResponseWriter, r)
-				return
-			}
-
-			// We now know the resource that was requested, so we can fill it into our log entry
-			logEntry.Request.Resource = route.Path
-
-			// If it hasn't been disabled, validate the request against the OpenAPI spec.
-			if !options.DisableRequestValidation {
-				requestValidationInput := &openapi3filter.RequestValidationInput{
-					Request:    r,
-					PathParams: pathParams,
-					Route:      route,
-					Options: &openapi3filter.Options{
-						AuthenticationFunc: func(ctx context.Context, ai *openapi3filter.AuthenticationInput) error {
-							authCallback, hasAuthCallback := options.AuthCallbacks[ai.SecuritySchemeName]
-							if !hasAuthCallback {
-								return ErrorAuthSchemeNotImplemented{ai.SecuritySchemeName}
-							}
-							return authCallback(ctx, ai)
-						},
-					},
-				}
-				err = openapi3filter.ValidateRequest(context.Background(), requestValidationInput)
-				if err != nil {
-					// If the err is an openapi3filter RequestError, we can extract more information from the err...
-					if err, isRequestErr := err.(*openapi3filter.RequestError); isRequestErr {
-						// TODO: Using strings.Contains is janky here and may break - should replace with something more reliable
-						// See the following open issue on the kin-openapi repo: https://github.com/getkin/kin-openapi/issues/477
-						// TODO: Open source contribution to kin-openapi?
-						if strings.Contains(err.Reason, "header Content-Type has unexpected value") {
-							options.ErrCallback(ErrorRequestContentTypeInvalid{r.Header.Get("Content-Type"), route.Path}, localResponseWriter, r)
-							return
-						}
-						if strings.Contains(err.Error(), "body has an error") {
-							options.ErrCallback(ErrorRequestBodyInvalid{err}, localResponseWriter, r)
-							return
-						}
-						if strings.Contains(err.Error(), "header has an error") {
-							options.ErrCallback(ErrorRequestHeadersInvalid{err}, localResponseWriter, r)
-							return
-						}
-						if strings.Contains(err.Error(), "query has an error") {
-							options.ErrCallback(ErrorRequestQueryParamsInvalid{err}, localResponseWriter, r)
-							return
-						}
-						if strings.Contains(err.Error(), "path has an error") {
-							options.ErrCallback(ErrorRequestPathParamsInvalid{err}, localResponseWriter, r)
-							return
-						}
-					}
-
-					// If the validation fails due to a security requirement, we pass a SecurityRequirementsError to the ErrCallback
-					if err, isSecurityErr := err.(*openapi3filter.SecurityRequirementsError); isSecurityErr {
-						options.ErrCallback(ErrorAuthNoMatchingScheme{err}, localResponseWriter, r)
-						return
-					}
-
-					// Else, we just use a non-specific ValidationError error
+			// Check there's a corresponding route for this request if we have a router
+			var route *routers.Route
+			var pathParams map[string]string
+			if router != nil {
+				route, pathParams, err = router.FindRoute(r)
+				if err == routers.ErrMethodNotAllowed {
+					options.ErrCallback(ErrorUnsupportedMethod{r.URL.Path, r.Method}, localResponseWriter, r)
+					return
+				} else if err == routers.ErrPathNotFound {
+					options.ErrCallback(ErrorRouteNotFound{r.URL.Path}, localResponseWriter, r)
+					return
+				} else if err != nil {
 					options.ErrCallback(ErrorAtRequestUnspecified{err}, localResponseWriter, r)
 					return
+				}
+
+				// We now know the resource that was requested, so we can fill it into our log entry
+				logEntry.Request.Resource = route.Path
+
+				// If it hasn't been disabled, validate the request against the OpenAPI spec.
+				if !options.DisableRequestValidation {
+					requestValidationInput := &openapi3filter.RequestValidationInput{
+						Request:    r,
+						PathParams: pathParams,
+						Route:      route,
+						Options: &openapi3filter.Options{
+							AuthenticationFunc: func(ctx context.Context, ai *openapi3filter.AuthenticationInput) error {
+								authCallback, hasAuthCallback := options.AuthCallbacks[ai.SecuritySchemeName]
+								if !hasAuthCallback {
+									return ErrorAuthSchemeNotImplemented{ai.SecuritySchemeName}
+								}
+								return authCallback(ctx, ai)
+							},
+						},
+					}
+					err = openapi3filter.ValidateRequest(context.Background(), requestValidationInput)
+					if err != nil {
+						// If the err is an openapi3filter RequestError, we can extract more information from the err...
+						if err, isRequestErr := err.(*openapi3filter.RequestError); isRequestErr {
+							// TODO: Using strings.Contains is janky here and may break - should replace with something more reliable
+							// See the following open issue on the kin-openapi repo: https://github.com/getkin/kin-openapi/issues/477
+							// TODO: Open source contribution to kin-openapi?
+							if strings.Contains(err.Reason, "header Content-Type has unexpected value") {
+								options.ErrCallback(ErrorRequestContentTypeInvalid{r.Header.Get("Content-Type"), route.Path}, localResponseWriter, r)
+								return
+							}
+							if strings.Contains(err.Error(), "body has an error") {
+								options.ErrCallback(ErrorRequestBodyInvalid{err}, localResponseWriter, r)
+								return
+							}
+							if strings.Contains(err.Error(), "header has an error") {
+								options.ErrCallback(ErrorRequestHeadersInvalid{err}, localResponseWriter, r)
+								return
+							}
+							if strings.Contains(err.Error(), "query has an error") {
+								options.ErrCallback(ErrorRequestQueryParamsInvalid{err}, localResponseWriter, r)
+								return
+							}
+							if strings.Contains(err.Error(), "path has an error") {
+								options.ErrCallback(ErrorRequestPathParamsInvalid{err}, localResponseWriter, r)
+								return
+							}
+						}
+
+						// If the validation fails due to a security requirement, we pass a SecurityRequirementsError to the ErrCallback
+						if err, isSecurityErr := err.(*openapi3filter.SecurityRequirementsError); isSecurityErr {
+							options.ErrCallback(ErrorAuthNoMatchingScheme{err}, localResponseWriter, r)
+							return
+						}
+
+						// Else, we just use a non-specific ValidationError error
+						options.ErrCallback(ErrorAtRequestUnspecified{err}, localResponseWriter, r)
+						return
+					}
 				}
 			}
 
@@ -184,8 +191,8 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 			next.ServeHTTP(chainResponseWriter, r)
 			logEntry.ExecutionTime = float64(time.Since(startTime).Milliseconds())
 
-			// If it hasn't been disabled, validate the response against the openapi spec
-			if !options.DisableResponseValidation {
+			// If it hasn't been disabled, and we were able to determine the route and path params, validate the response against the openapi spec
+			if !options.DisableResponseValidation && route != nil && pathParams != nil {
 				responseValidationInput := &openapi3filter.ResponseValidationInput{
 					RequestValidationInput: &openapi3filter.RequestValidationInput{
 						Request:    r,

--- a/middlewares/http/middleware.go
+++ b/middlewares/http/middleware.go
@@ -111,7 +111,7 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 			// Check there's a corresponding route for this request if we have a router
 			var route *routers.Route
 			var pathParams map[string]string
-			if router != nil {
+			if router != nil && (options.EnableRequestValidation || options.EnableResponseValidation) {
 				route, pathParams, err = router.FindRoute(r)
 				if err == routers.ErrMethodNotAllowed {
 					options.ErrCallback(ErrorUnsupportedMethod{r.URL.Path, r.Method}, localResponseWriter, r)
@@ -123,65 +123,64 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 					options.ErrCallback(ErrorAtRequestUnspecified{err}, localResponseWriter, r)
 					return
 				}
-
 				// We now know the resource that was requested, so we can fill it into our log entry
 				logEntry.Request.Resource = route.Path
+			}
 
-				// If it hasn't been disabled, validate the request against the OpenAPI spec.
-				if !options.DisableRequestValidation {
-					requestValidationInput := &openapi3filter.RequestValidationInput{
-						Request:    r,
-						PathParams: pathParams,
-						Route:      route,
-						Options: &openapi3filter.Options{
-							AuthenticationFunc: func(ctx context.Context, ai *openapi3filter.AuthenticationInput) error {
-								authCallback, hasAuthCallback := options.AuthCallbacks[ai.SecuritySchemeName]
-								if !hasAuthCallback {
-									return ErrorAuthSchemeNotImplemented{ai.SecuritySchemeName}
-								}
-								return authCallback(ctx, ai)
-							},
+			// If it has been enabled, and we were able to determine the route and path params, validate the request against the openapi spec
+			if options.EnableRequestValidation && route != nil && pathParams != nil {
+				requestValidationInput := &openapi3filter.RequestValidationInput{
+					Request:    r,
+					PathParams: pathParams,
+					Route:      route,
+					Options: &openapi3filter.Options{
+						AuthenticationFunc: func(ctx context.Context, ai *openapi3filter.AuthenticationInput) error {
+							authCallback, hasAuthCallback := options.AuthCallbacks[ai.SecuritySchemeName]
+							if !hasAuthCallback {
+								return ErrorAuthSchemeNotImplemented{ai.SecuritySchemeName}
+							}
+							return authCallback(ctx, ai)
 						},
-					}
-					err = openapi3filter.ValidateRequest(context.Background(), requestValidationInput)
-					if err != nil {
-						// If the err is an openapi3filter RequestError, we can extract more information from the err...
-						if err, isRequestErr := err.(*openapi3filter.RequestError); isRequestErr {
-							// TODO: Using strings.Contains is janky here and may break - should replace with something more reliable
-							// See the following open issue on the kin-openapi repo: https://github.com/getkin/kin-openapi/issues/477
-							// TODO: Open source contribution to kin-openapi?
-							if strings.Contains(err.Reason, "header Content-Type has unexpected value") {
-								options.ErrCallback(ErrorRequestContentTypeInvalid{r.Header.Get("Content-Type"), route.Path}, localResponseWriter, r)
-								return
-							}
-							if strings.Contains(err.Error(), "body has an error") {
-								options.ErrCallback(ErrorRequestBodyInvalid{err}, localResponseWriter, r)
-								return
-							}
-							if strings.Contains(err.Error(), "header has an error") {
-								options.ErrCallback(ErrorRequestHeadersInvalid{err}, localResponseWriter, r)
-								return
-							}
-							if strings.Contains(err.Error(), "query has an error") {
-								options.ErrCallback(ErrorRequestQueryParamsInvalid{err}, localResponseWriter, r)
-								return
-							}
-							if strings.Contains(err.Error(), "path has an error") {
-								options.ErrCallback(ErrorRequestPathParamsInvalid{err}, localResponseWriter, r)
-								return
-							}
-						}
-
-						// If the validation fails due to a security requirement, we pass a SecurityRequirementsError to the ErrCallback
-						if err, isSecurityErr := err.(*openapi3filter.SecurityRequirementsError); isSecurityErr {
-							options.ErrCallback(ErrorAuthNoMatchingScheme{err}, localResponseWriter, r)
+					},
+				}
+				err = openapi3filter.ValidateRequest(context.Background(), requestValidationInput)
+				if err != nil {
+					// If the err is an openapi3filter RequestError, we can extract more information from the err...
+					if err, isRequestErr := err.(*openapi3filter.RequestError); isRequestErr {
+						// TODO: Using strings.Contains is janky here and may break - should replace with something more reliable
+						// See the following open issue on the kin-openapi repo: https://github.com/getkin/kin-openapi/issues/477
+						// TODO: Open source contribution to kin-openapi?
+						if strings.Contains(err.Reason, "header Content-Type has unexpected value") {
+							options.ErrCallback(ErrorRequestContentTypeInvalid{r.Header.Get("Content-Type"), route.Path}, localResponseWriter, r)
 							return
 						}
+						if strings.Contains(err.Error(), "body has an error") {
+							options.ErrCallback(ErrorRequestBodyInvalid{err}, localResponseWriter, r)
+							return
+						}
+						if strings.Contains(err.Error(), "header has an error") {
+							options.ErrCallback(ErrorRequestHeadersInvalid{err}, localResponseWriter, r)
+							return
+						}
+						if strings.Contains(err.Error(), "query has an error") {
+							options.ErrCallback(ErrorRequestQueryParamsInvalid{err}, localResponseWriter, r)
+							return
+						}
+						if strings.Contains(err.Error(), "path has an error") {
+							options.ErrCallback(ErrorRequestPathParamsInvalid{err}, localResponseWriter, r)
+							return
+						}
+					}
 
-						// Else, we just use a non-specific ValidationError error
-						options.ErrCallback(ErrorAtRequestUnspecified{err}, localResponseWriter, r)
+					// If the validation fails due to a security requirement, we pass a SecurityRequirementsError to the ErrCallback
+					if err, isSecurityErr := err.(*openapi3filter.SecurityRequirementsError); isSecurityErr {
+						options.ErrCallback(ErrorAuthNoMatchingScheme{err}, localResponseWriter, r)
 						return
 					}
+
+					// Else, we just use a non-specific ValidationError error
+					options.ErrCallback(ErrorAtRequestUnspecified{err}, localResponseWriter, r)
+					return
 				}
 			}
 
@@ -191,8 +190,8 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 			next.ServeHTTP(chainResponseWriter, r)
 			logEntry.ExecutionTime = float64(time.Since(startTime).Milliseconds())
 
-			// If it hasn't been disabled, and we were able to determine the route and path params, validate the response against the openapi spec
-			if !options.DisableResponseValidation && route != nil && pathParams != nil {
+			// If it has been enabled, and we were able to determine the route and path params, validate the response against the openapi spec
+			if options.EnableResponseValidation && route != nil && pathParams != nil {
 				responseValidationInput := &openapi3filter.ResponseValidationInput{
 					RequestValidationInput: &openapi3filter.RequestValidationInput{
 						Request:    r,

--- a/middlewares/http/middleware_test.go
+++ b/middlewares/http/middleware_test.go
@@ -53,8 +53,10 @@ var authCallbacks = map[string]openapi3filter.AuthenticationFunc{
 
 func TestValidRequestAndResponse(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		AuthCallbacks:   authCallbacks,
+		OpenapiSpecPath:          "./test-spec.yaml",
+		AuthCallbacks:            authCallbacks,
+		EnableRequestValidation:  true,
+		EnableResponseValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -124,8 +126,9 @@ func TestInvalidSpec(t *testing.T) {
 
 func TestRequestToInvalidRoute(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		DebugErrs:       true,
+		OpenapiSpecPath:         "./test-spec.yaml",
+		DebugErrs:               true,
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -148,7 +151,8 @@ func TestRequestToInvalidRoute(t *testing.T) {
 
 func TestDebugErrsDisabled(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
+		OpenapiSpecPath:         "./test-spec.yaml",
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -171,8 +175,9 @@ func TestDebugErrsDisabled(t *testing.T) {
 
 func TestRequestWithDisallowedMethod(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		DebugErrs:       true,
+		OpenapiSpecPath:         "./test-spec.yaml",
+		DebugErrs:               true,
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -195,9 +200,10 @@ func TestRequestWithDisallowedMethod(t *testing.T) {
 
 func TestRequestWithInvalidHeader(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		AuthCallbacks:   authCallbacks,
-		DebugErrs:       true,
+		OpenapiSpecPath:         "./test-spec.yaml",
+		AuthCallbacks:           authCallbacks,
+		DebugErrs:               true,
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -230,9 +236,10 @@ func TestRequestWithInvalidHeader(t *testing.T) {
 
 func TestRequestWithInvalidQueryParam(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		AuthCallbacks:   authCallbacks,
-		DebugErrs:       true,
+		OpenapiSpecPath:         "./test-spec.yaml",
+		AuthCallbacks:           authCallbacks,
+		DebugErrs:               true,
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -264,9 +271,10 @@ func TestRequestWithInvalidQueryParam(t *testing.T) {
 
 func TestRequestWithInvalidPathParam(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		AuthCallbacks:   authCallbacks,
-		DebugErrs:       true,
+		OpenapiSpecPath:         "./test-spec.yaml",
+		AuthCallbacks:           authCallbacks,
+		DebugErrs:               true,
+		EnableRequestValidation: true,
 	})
 	handler := middleware(healthHandler)
 	responseRecorder := httptest.NewRecorder()
@@ -297,9 +305,10 @@ func TestRequestWithInvalidPathParam(t *testing.T) {
 
 func TestRequestWithInvalidBody(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		AuthCallbacks:   authCallbacks,
-		DebugErrs:       true,
+		OpenapiSpecPath:         "./test-spec.yaml",
+		AuthCallbacks:           authCallbacks,
+		DebugErrs:               true,
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -364,8 +373,9 @@ func TestRequestWithValidAuth(t *testing.T) {
 
 func TestRequestWithUnimplementedAuth(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		DebugErrs:       true,
+		OpenapiSpecPath:         "./test-spec.yaml",
+		DebugErrs:               true,
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -397,9 +407,10 @@ func TestRequestWithUnimplementedAuth(t *testing.T) {
 
 func TestRequestWithMissingAuth(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		AuthCallbacks:   authCallbacks,
-		DebugErrs:       true,
+		OpenapiSpecPath:         "./test-spec.yaml",
+		AuthCallbacks:           authCallbacks,
+		DebugErrs:               true,
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -430,9 +441,10 @@ func TestRequestWithMissingAuth(t *testing.T) {
 
 func TestRequestWithInvalidAuth(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		AuthCallbacks:   authCallbacks,
-		DebugErrs:       true,
+		OpenapiSpecPath:         "./test-spec.yaml",
+		AuthCallbacks:           authCallbacks,
+		DebugErrs:               true,
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -464,9 +476,10 @@ func TestRequestWithInvalidAuth(t *testing.T) {
 
 func TestInvalidResponseBody(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		AuthCallbacks:   authCallbacks,
-		DebugErrs:       true,
+		OpenapiSpecPath:          "./test-spec.yaml",
+		AuthCallbacks:            authCallbacks,
+		DebugErrs:                true,
+		EnableResponseValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandlerWithWrongResponseBody)
@@ -498,9 +511,10 @@ func TestInvalidResponseBody(t *testing.T) {
 
 func TestInvalidResponseCode(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		AuthCallbacks:   authCallbacks,
-		DebugErrs:       true,
+		OpenapiSpecPath:          "./test-spec.yaml",
+		AuthCallbacks:            authCallbacks,
+		DebugErrs:                true,
+		EnableResponseValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandlerWithWrongResponseCode)
@@ -532,8 +546,7 @@ func TestInvalidResponseCode(t *testing.T) {
 
 func TestDisabledRequestValidation(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath:          "./test-spec.yaml",
-		DisableRequestValidation: true,
+		OpenapiSpecPath: "./test-spec.yaml",
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -560,9 +573,8 @@ func TestDisabledRequestValidation(t *testing.T) {
 
 func TestDisabledResponseValidation(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath:           "./test-spec.yaml",
-		AuthCallbacks:             authCallbacks,
-		DisableResponseValidation: true,
+		OpenapiSpecPath: "./test-spec.yaml",
+		AuthCallbacks:   authCallbacks,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandlerWithWrongResponseBody)
@@ -590,9 +602,10 @@ func TestDisabledResponseValidation(t *testing.T) {
 
 func TestUnexpectedContentType(t *testing.T) {
 	middleware, err := GetMiddleware(&Options{
-		OpenapiSpecPath: "./test-spec.yaml",
-		AuthCallbacks:   authCallbacks,
-		DebugErrs:       true,
+		OpenapiSpecPath:         "./test-spec.yaml",
+		AuthCallbacks:           authCallbacks,
+		DebugErrs:               true,
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)
@@ -627,6 +640,7 @@ func TestCustomXMLDecoder(t *testing.T) {
 				return xml2map.NewDecoder(r).Decode()
 			},
 		},
+		EnableRequestValidation: true,
 	})
 	require.Nil(t, err)
 	handler := middleware(healthHandler)

--- a/middlewares/http/options.go
+++ b/middlewares/http/options.go
@@ -10,7 +10,7 @@ import (
 
 // Options is an options struct used when creating a Firetail middleware (GetMiddleware)
 type Options struct {
-	// SpecPath is the path at which your openapi spec can be found
+	// SpecPath is the path at which your openapi spec can be found. Supplying an empty string disables any validation.
 	OpenapiSpecPath string
 
 	// LogApiKey is the API key which will be used when sending logs to the Firetail logging API. This value should typically be loaded

--- a/middlewares/http/options.go
+++ b/middlewares/http/options.go
@@ -40,11 +40,13 @@ type Options struct {
 	// documentation
 	AuthCallbacks map[string]openapi3filter.AuthenticationFunc
 
-	// DisableRequestValidation is an optional flag which, if set to true, disables request validation
-	DisableRequestValidation bool
+	// EnableRequestValidation is an optional flag which, if set to true, enables request validation against the openapi spec provided -
+	// if no openapi spec is provided, then no validation will be performed
+	EnableRequestValidation bool
 
-	// DisableResponseValidation is an optional flag which, if set to true, disables response validation
-	DisableResponseValidation bool
+	// EnableResponseValidation is an optional flag which, if set to true, enables response validation against the openapi spec provided -
+	// if no openapi spec is provided, then no validation will be performed
+	EnableResponseValidation bool
 
 	// CustomBodyDecoders is a map of Content-Type header values to openapi3 decoders - if the kin-openapi module does not support your
 	// Content-Type by default, you will need to add a custom decoder here

--- a/middlewares/http/options.go
+++ b/middlewares/http/options.go
@@ -14,11 +14,11 @@ type Options struct {
 	OpenapiSpecPath string
 
 	// LogApiKey is the API key which will be used when sending logs to the Firetail logging API. This value should typically be loaded
-	// in from an environment variable
+	// in from an environment variable. If unset, no logs will be forwarded to the Firetail SaaS
 	LogApiKey string
 
 	// LogApiUrl is the URL of the Firetail logging API endpoint to which logs will be sent. This value should typically be loaded in from
-	// an environment variable
+	// an environment variable. If unset, the default value is the Firetail SaaS' bulk logs endpoint
 	LogApiUrl string
 
 	// LogBatchCallback is an optional callback which is provided with a batch of Firetail log entries ready to be sent to Firetail. The

--- a/middlewares/http/options.go
+++ b/middlewares/http/options.go
@@ -13,13 +13,14 @@ type Options struct {
 	// SpecPath is the path at which your openapi spec can be found. Supplying an empty string disables any validation.
 	OpenapiSpecPath string
 
-	// LogApiKey is the API key which will be used when sending logs to the Firetail logging API. This value should typically be loaded
-	// in from an environment variable. If unset, no logs will be forwarded to the Firetail SaaS
-	LogApiKey string
+	// LogsApiToken is the API token which will be used when sending logs to the Firetail logging API with the default batch callback.
+	// This value should typically be loaded in from an environment variable. If unset, the default batch callback will not forward
+	// logs to the Firetail SaaS
+	LogsApiToken string
 
-	// LogApiUrl is the URL of the Firetail logging API endpoint to which logs will be sent. This value should typically be loaded in from
-	// an environment variable. If unset, the default value is the Firetail SaaS' bulk logs endpoint
-	LogApiUrl string
+	// LogsApiUrl is the URL of the Firetail logging API endpoint to which logs will be sent by the default batch callback. This value
+	// should typically be loaded in from an environment variable. If unset, the default value is the Firetail SaaS' bulk logs endpoint
+	LogsApiUrl string
 
 	// LogBatchCallback is an optional callback which is provided with a batch of Firetail log entries ready to be sent to Firetail. The
 	// default callback sends log entries to the Firetail logging API. It may be customised to, for example, additionally log the entries
@@ -59,8 +60,8 @@ type Options struct {
 }
 
 func (o *Options) setDefaults() {
-	if o.LogApiUrl == "" {
-		o.LogApiUrl = "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk"
+	if o.LogsApiUrl == "" {
+		o.LogsApiUrl = "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk"
 	}
 
 	if o.ErrCallback == nil {


### PR DESCRIPTION
 - Makes the appspec optional, so the lib can just be used for forwarding to the Firetail SaaS (#21)
 - Makes the request/response validation disabled by default (#22)
 - Adds a getting started section to the README (#23)
 - Docs the default behaviour for LogApiKey and LogApiUrl option fields (#24)
 - Adds a gopkg badge to the README (#25)