### PR TITLE
Rename LogApiUrl and LogApiKey to LogsApiUrl and LogsApiToken to be more consistent with SaaS

### DIFF
--- a/examples/minimal-chi/main.go
+++ b/examples/minimal-chi/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	firetailMiddleware, err := firetail.GetMiddleware(&firetail.Options{
 		OpenapiSpecPath: "app-spec.yaml",
-		LogApiKey:       os.Getenv("FIRETAIL_LOG_API_KEY"),
+		LogsApiToken:    os.Getenv("FIRETAIL_LOG_API_KEY"),
 	})
 	if err != nil {
 		panic(err)

--- a/examples/minimal-http/main.go
+++ b/examples/minimal-http/main.go
@@ -26,7 +26,7 @@ func main() {
 	// Get a firetail middleware
 	firetailMiddleware, err := firetail.GetMiddleware(&firetail.Options{
 		OpenapiSpecPath: "app-spec.yaml",
-		LogApiKey:       os.Getenv("FIRETAIL_LOG_API_KEY"),
+		LogsApiToken:    os.Getenv("FIRETAIL_LOG_API_KEY"),
 	})
 	if err != nil {
 		panic(err)

--- a/middlewares/http/middleware.go
+++ b/middlewares/http/middleware.go
@@ -49,8 +49,8 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 		MaxBatchSize:  1024 * 512,
 		MaxLogAge:     time.Minute,
 		BatchCallback: options.LogBatchCallback,
-		LogApiKey:     options.LogApiKey,
-		LogApiUrl:     options.LogApiUrl,
+		LogApiKey:     options.LogsApiToken,
+		LogApiUrl:     options.LogsApiUrl,
 	})
 
 	middleware := func(next http.Handler) http.Handler {

--- a/middlewares/http/options.go
+++ b/middlewares/http/options.go
@@ -13,13 +13,14 @@ type Options struct {
 	// SpecPath is the path at which your openapi spec can be found. Supplying an empty string disables any validation.
 	OpenapiSpecPath string
 
-	// LogApiKey is the API key which will be used when sending logs to the Firetail logging API. This value should typically be loaded
-	// in from an environment variable. If unset, no logs will be forwarded to the Firetail SaaS
-	LogApiKey string
+	// LogsApiToken is the API token which will be used when sending logs to the Firetail logging API with the default batch callback.
+	// This value should typically be loaded in from an environment variable. If unset, the default batch callback will not forward
+	// logs to the Firetail SaaS
+	LogsApiToken string
 
-	// LogApiUrl is the URL of the Firetail logging API endpoint to which logs will be sent. This value should typically be loaded in from
-	// an environment variable. If unset, the default value is the Firetail SaaS' bulk logs endpoint
-	LogApiUrl string
+	// LogsApiUrl is the URL of the Firetail logging API endpoint to which logs will be sent by the default batch callback. This value
+	// should typically be loaded in from an environment variable. If unset, the default value is the Firetail SaaS' bulk logs endpoint
+	LogsApiUrl string
 
 	// LogBatchCallback is an optional callback which is provided with a batch of Firetail log entries ready to be sent to Firetail. The
 	// default callback sends log entries to the Firetail logging API. It may be customised to, for example, additionally log the entries
@@ -59,8 +60,8 @@ type Options struct {
 }
 
 func (o *Options) setDefaults() {
-	if o.LogApiUrl == "" {
-		o.LogApiUrl = "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk"
+	if o.LogsApiUrl == "" {
+		o.LogsApiUrl = "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk"
 	}
 
 	if o.ErrCallback == nil {


### PR DESCRIPTION
`LogApiKey` was referred to as a key in the lib as its used in the header named `x-ft-api-key`, however it's referred to as a token throughout the SaaS UI, which developers are more likely to see.