### PR TITLE
Add continue-on-error: true to codecov upload step

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
+        continue-on-error: true


### PR DESCRIPTION
Missing continue-on-error: true on the codecov upload step.