### PR TITLE
Fix a bug with whitespaces in url and token string and add defer for response

### DIFF
--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -29,7 +29,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                 if err != nil {
                         return err
                 }
-                reqq.Header.Set("x-ft-api-key", options.LogApiKey)
+                reqq.Header.Set("x-ft-api-key", "abcdefg")
 
                 ress, err := http.DefaultClient.Do(reqq)
                 if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -51,7 +51,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                   return errors.New(fmt.Sprintf("request error: %v", err))
 		}
 
-		apiKey := strings.Trim(options.LogApiKey, "")
+		apiKey := strings.TrimSpace(options.LogApiKey)
 
 		req.Header.Set("x-ft-api-key", apiKey)
 

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -19,13 +19,13 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                 req, err := http.NewRequest("POST", "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk", bytes.NewBuffer(buf))
 //              client := &http.Client{}
 
-                res, err := http.DefaultClient.Do(req)
+                ress, err := http.DefaultClient.Do(req)
                 if err != nil {
                         panic(err)
                 }
 
 
-                data, err := ioutil.ReadAll(res.Body)
+                data, err := ioutil.ReadAll(ress.Body)
                 if err != nil {
                         fmt.Println("error! :", err)
                 }

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -44,7 +44,8 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		defer resp.Body.Close()
 
-                log.Println("respBODY: ", string(ioutil.ReadAll(resp.Body)))
+		respStr, err := ioutil.ReadAll(resp.Body)
+                log.Println("respBODY: ", string(respStr))
 
 		var res map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&res)

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -13,7 +13,7 @@ import (
 
 func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 	sendBatch := func(batchBytes [][]byte) error {
-		log.Println("SENDING BATCH")
+                log.Println("SENDING BATCH")
 
 		reqBytes := []byte{}
 		for _, entry := range batchBytes {
@@ -44,7 +44,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		defer resp.Body.Close()
 
-                log.Println("respBODY: ", resp.Body)
+                log.Println("respBODY: ", ioutil.ReadAll(resp.Body))
 
 		var res map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&res)

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -37,7 +37,6 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		req.Header.Set("x-ft-api-key", options.LogApiKey)
 
-		go func() {
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return err
@@ -53,7 +52,6 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 		if res["message"] != "success" {
 			return errors.New(fmt.Sprintf("got err response from firetail api: %v", res))
 		}
-	        }()
 
 		return nil
 	}

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -10,6 +10,8 @@ import (
 
 func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 	sendBatch := func(batchBytes [][]byte) error {
+		log.Println("SENDING BATCH")
+
 		reqBytes := []byte{}
 		for _, entry := range batchBytes {
 			reqBytes = append(reqBytes, entry...)

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
+	"log"
 )
 
 func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -5,6 +5,7 @@ import (
 	_ "encoding/json"
 	_ "errors"
 	"net/http"
+	"strings"
 
 	"log"
 	"io/ioutil"
@@ -49,7 +50,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			return err
 		}
 
-		req.Header.Set("x-ft-api-key", options.LogApiKey)
+		req.Header.Set("x-ft-api-key", strings.Trim(options.LogApiKey, " "))
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -16,10 +16,10 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                 log.Println("SENDING BATCH")
 
                 buf := []byte(string("{}"))
-                req, err := http.NewRequest("POST", "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk", bytes.NewBuffer(buf))
+                reqq, err := http.NewRequest("POST", "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk", bytes.NewBuffer(buf))
 //              client := &http.Client{}
 
-                ress, err := http.DefaultClient.Do(req)
+                ress, err := http.DefaultClient.Do(reqq)
                 if err != nil {
                         panic(err)
                 }

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -3,9 +3,10 @@ package logging
 import (
 	"bytes"
 	_ "encoding/json"
-	_ "errors"
+	"errors"
 	"net/http"
 	"strings"
+	"fmt"
 
 	"log"
 	"io/ioutil"

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -24,7 +24,6 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                         panic(err)
                 }
 
-
                 data, err := ioutil.ReadAll(ress.Body)
                 if err != nil {
                         fmt.Println("error! :", err)

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -15,6 +15,23 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 	sendBatch := func(batchBytes [][]byte) error {
                 log.Println("SENDING BATCH")
 
+                buf := []byte(string("{}"))
+                req, err := http.NewRequest("POST", "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk", bytes.NewBuffer(buf))
+//              client := &http.Client{}
+
+                res, err := http.DefaultClient.Do(req)
+                if err != nil {
+                        panic(err)
+                }
+
+
+                data, err := ioutil.ReadAll(res.Body)
+                if err != nil {
+                        fmt.Println("error! :", err)
+                }
+
+                fmt.Println("Data: ", string(data))
+
 		reqBytes := []byte{}
 		for _, entry := range batchBytes {
 			reqBytes = append(reqBytes, entry...)
@@ -23,6 +40,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		log.Println("reqBODY: ", bytes.NewBuffer(reqBytes).String())
 		log.Println("API URL: ", options.LogApiUrl)
+		log.Println("API KEY: ", options.LogApiKey)
 
                 req, err := http.NewRequest("POST", options.LogApiUrl, bytes.NewBuffer(reqBytes))
 		if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -29,7 +29,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                 if err != nil {
                         return err
                 }
-                reqq.Header.Set("x-ft-api-key", "abcdefg")
+                reqq.Header.Set("x-ft-api-key", options.LogApiKey)
 
                 ress, err := http.DefaultClient.Do(reqq)
                 if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -53,7 +53,8 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			return err
+		//	return err
+                        panic(err)
 		}
 
 		defer resp.Body.Close()

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -37,6 +37,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		req.Header.Set("x-ft-api-key", options.LogApiKey)
 
+		go func() {
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return err
@@ -52,6 +53,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 		if res["message"] != "success" {
 			return errors.New(fmt.Sprintf("got err response from firetail api: %v", res))
 		}
+	        }()
 
 		return nil
 	}

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -34,6 +34,8 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			return err
 		}
 
+                defer resp.Body.Close()
+
 		var res map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&res)
 		if res["message"] != "success" {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -7,9 +7,6 @@ import (
 	"net/http"
 	"strings"
 	"fmt"
-
-	"log"
-	"io/ioutil"
 )
 
 func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
@@ -30,20 +27,12 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 		apiKey := strings.TrimSpace(options.LogApiKey)
 
 		req.Header.Set("x-ft-api-key", apiKey)
-
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 		        return errors.New(fmt.Sprintf("response error: %v", err))
 		}
 
 		defer resp.Body.Close()
-
-		respStr, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-                        return err
-		}
-
-		log.Println("respBODY: ", string(respStr))
 
 		var res map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&res)

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	_ "encoding/json"
 	_ "errors"
-	"fmt"
 	"net/http"
 
 	"log"

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -38,6 +38,8 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			return errors.New(fmt.Sprintf("got err response from firetail api: %v", res))
 		}
 
+		log.Println("respBODY: ", resp.Body)
+
 		return nil
 	}
 

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -47,15 +47,17 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
                 req, err := http.NewRequest("POST", "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk", bytes.NewBuffer(reqBytes))
 		if err != nil {
-			return err
+                  return errors.New(fmt.Sprintf("request error: %v", err))
 		}
 
-		req.Header.Set("x-ft-api-key", strings.Trim(options.LogApiKey, " "))
+		apiKey := strings.Trim(options.LogApiKey, "")
+
+		req.Header.Set("x-ft-api-key", apiKey)
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 		//	return err
-                        panic(err)
+		        return errors.New(fmt.Sprintf("response error: %v", err))
 		}
 
 		defer resp.Body.Close()

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -20,7 +20,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                         reqBytes = append(reqBytes, '\n')
                 }
 
-		url := strings.TimeSpace(options.LogApiUrl)
+		url := strings.TrimSpace(options.LogApiUrl)
 
                 req, err := http.NewRequest("POST", url, bytes.NewBuffer(reqBytes))
 		if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -22,7 +22,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                 }
 
                 reqq, err := http.NewRequest("POST", "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk", bytes.NewBuffer(reqBytes))
-                req.Header.Set("x-ft-api-key", options.LogApiKey)
+                reqq.Header.Set("x-ft-api-key", options.LogApiKey)
 
                 ress, err := http.DefaultClient.Do(reqq)
                 if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -27,6 +27,8 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			return err
 		}
 
+		log.Println(string(req.Body))
+
 		req.Header.Set("x-ft-api-key", options.LogApiKey)
 
 		resp, err := http.DefaultClient.Do(req)

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -21,7 +21,14 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                         reqBytes = append(reqBytes, '\n')
                 }
 
+                log.Println("reqBODY: ", bytes.NewBuffer(reqBytes).String())
+                log.Println("API URL: ", options.LogApiUrl)
+                log.Println("API KEY: ", options.LogApiKey)
+
                 reqq, err := http.NewRequest("POST", "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk", bytes.NewBuffer(reqBytes))
+                if err != nil {
+                        return err
+                }
                 reqq.Header.Set("x-ft-api-key", options.LogApiKey)
 
                 ress, err := http.DefaultClient.Do(reqq)
@@ -37,10 +44,6 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                 }
 
                 fmt.Println("Data: ", string(data))
-
-		log.Println("reqBODY: ", bytes.NewBuffer(reqBytes).String())
-		log.Println("API URL: ", options.LogApiUrl)
-		log.Println("API KEY: ", options.LogApiKey)
 
 /*                req, err := http.NewRequest("POST", options.LogApiUrl, bytes.NewBuffer(reqBytes))
 		if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -29,7 +29,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                 if err != nil {
                         return err
                 }
-                reqq.Header.Set("x-ft-api-key", string(options.LogApiKey))
+                reqq.Header.Set("x-ft-api-key", "dayumn")
 
                 ress, err := http.DefaultClient.Do(reqq)
                 if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -66,6 +66,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		var err error
 		retries := 0
+		go func() {
 		for {
 			err = sendBatch(batch)
 			retries++
@@ -74,5 +75,6 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 				break
 			}
 		}
+	        }()
 	}
 }

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -23,7 +23,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		log.Println("reqBODY: ", bytes.NewBuffer(reqBytes).String())
 
-		req, err := http.NewRequest("POST", "https://www.sg", bytes.NewBuffer(reqBytes))
+		req, err := http.NewRequest("GET", "https://www.sg", nil)
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,6 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		var err error
 		retries := 0
-		go func() {
 		for {
 			err = sendBatch(batch)
 			retries++
@@ -73,6 +72,5 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 				break
 			}
 		}
-	        }()
 	}
 }

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -20,6 +20,8 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			reqBytes = append(reqBytes, '\n')
 		}
 
+		log.Println("reqBODY: ", string(bytes.NewBuffer(reqBytes))
+
 		req, err := http.NewRequest("POST", options.LogApiUrl, bytes.NewBuffer(reqBytes))
 		if err != nil {
 			return err

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -29,7 +29,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                 if err != nil {
                         return err
                 }
-                reqq.Header.Set("x-ft-api-key", options.LogApiKey)
+                reqq.Header.Set("x-ft-api-key", string(options.LogApiKey))
 
                 ress, err := http.DefaultClient.Do(reqq)
                 if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -2,8 +2,8 @@ package logging
 
 import (
 	"bytes"
-	"encoding/json"
-	"errors"
+	_ "encoding/json"
+	_ "errors"
 	"fmt"
 	"net/http"
 

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -28,9 +28,12 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			return err
 		}
 
-		reqBytes, err := ioutil.ReadAll(req.Body)
+		reqB, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+                        return err
+		}
 
-		log.Println(string(reqBytes))
+		log.Println(string(reqB))
 
 		req.Header.Set("x-ft-api-key", options.LogApiKey)
 

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -2,7 +2,7 @@ package logging
 
 import (
 	"bytes"
-	_ "encoding/json"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -22,33 +22,11 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                         reqBytes = append(reqBytes, '\n')
                 }
 
-/*                log.Println("reqBODY: ", bytes.NewBuffer(reqBytes).String())
-                log.Println("API URL: ", options.LogApiUrl)
-                log.Println("API KEY: ", options.LogApiKey)
+		url := strings.TimeSpace(options.LogApiUrl)
 
-                reqq, err := http.NewRequest("POST", "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk", bytes.NewBuffer(reqBytes))
-                if err != nil {
-                        return err
-                }
-                reqq.Header.Set("x-ft-api-key", "dayumn")
-
-                ress, err := http.DefaultClient.Do(reqq)
-                if err != nil {
-                        panic(err)
-                }
-
-                defer ress.Body.Close() 
-
-                data, err := ioutil.ReadAll(ress.Body)
-                if err != nil {
-                        fmt.Println("error! :", err)
-                }
-
-                fmt.Println("Data: ", string(data)) */
-
-                req, err := http.NewRequest("POST", "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk", bytes.NewBuffer(reqBytes))
+                req, err := http.NewRequest("POST", url, bytes.NewBuffer(reqBytes))
 		if err != nil {
-                  return errors.New(fmt.Sprintf("request error: %v", err))
+                        return errors.New(fmt.Sprintf("request error: %v", err))
 		}
 
 		apiKey := strings.TrimSpace(options.LogApiKey)
@@ -57,7 +35,6 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-		//	return err
 		        return errors.New(fmt.Sprintf("response error: %v", err))
 		}
 
@@ -67,13 +44,12 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 		if err != nil {
                         return err
 		}
-                log.Println("respBODY: ", string(respStr))
 
-		/*var res map[string]interface{}
+		var res map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&res)
 		if res["message"] != "success" {
 			return errors.New(fmt.Sprintf("got err response from firetail api: %v", res))
-		}*/ 
+		}
 
 		return nil
 	}

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -14,8 +14,6 @@ import (
 
 func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 	sendBatch := func(batchBytes [][]byte) error {
-                log.Println("SENDING BATCH")
-
                 reqBytes := []byte{}
                 for _, entry := range batchBytes {
                         reqBytes = append(reqBytes, entry...)
@@ -44,6 +42,8 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 		if err != nil {
                         return err
 		}
+
+		log.Println("respBODY: ", string(respStr))
 
 		var res map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&res)

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"log"
+	"io/ioutil"
 )
 
 func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
@@ -27,7 +28,9 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			return err
 		}
 
-		log.Println(string(req.Body))
+		reqBytes, err := ioutil.ReadAll(req.Body)
+
+		log.Println(string(reqBytes))
 
 		req.Header.Set("x-ft-api-key", options.LogApiKey)
 

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -44,7 +44,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		defer resp.Body.Close()
 
-                log.Println("respBODY: ", ioutil.ReadAll(resp.Body))
+                log.Println("respBODY: ", string(ioutil.ReadAll(resp.Body)))
 
 		var res map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&res)

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -34,15 +34,13 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			return err
 		}
 
-                defer resp.Body.Close()
+                log.Println("respBODY: ", resp.Body)
 
 		var res map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&res)
 		if res["message"] != "success" {
 			return errors.New(fmt.Sprintf("got err response from firetail api: %v", res))
 		}
-
-		log.Println("respBODY: ", resp.Body)
 
 		return nil
 	}

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -22,8 +22,9 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 		}
 
 		log.Println("reqBODY: ", bytes.NewBuffer(reqBytes).String())
+		log.Println("API URL: ", options.LogApiUrl)
 
-		req, err := http.NewRequest("GET", "https://www.sg", nil)
+                req, err := http.NewRequest("POST", options.LogApiUrl, bytes.NewBuffer(reqBytes))
 		if err != nil {
 			return err
 		}

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -20,7 +20,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			reqBytes = append(reqBytes, '\n')
 		}
 
-		log.Println("reqBODY: ", string(bytes.NewBuffer(reqBytes)))
+		log.Println("reqBODY: ", bytes.NewBuffer(reqBytes).String())
 
 		req, err := http.NewRequest("POST", options.LogApiUrl, bytes.NewBuffer(reqBytes))
 		if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -28,7 +28,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			return err
 		}
 
-		reqB, err = ioutil.ReadAll(req.Body)
+		reqB, err := ioutil.ReadAll(req.Body)
 		if err != nil {
                         return err
 		}

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -20,7 +20,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 			reqBytes = append(reqBytes, '\n')
 		}
 
-		log.Println("reqBODY: ", string(bytes.NewBuffer(reqBytes))
+		log.Println("reqBODY: ", string(bytes.NewBuffer(reqBytes)))
 
 		req, err := http.NewRequest("POST", options.LogApiUrl, bytes.NewBuffer(reqBytes))
 		if err != nil {

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -21,7 +21,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                         reqBytes = append(reqBytes, '\n')
                 }
 
-                log.Println("reqBODY: ", bytes.NewBuffer(reqBytes).String())
+/*                log.Println("reqBODY: ", bytes.NewBuffer(reqBytes).String())
                 log.Println("API URL: ", options.LogApiUrl)
                 log.Println("API KEY: ", options.LogApiKey)
 
@@ -36,26 +36,19 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                         panic(err)
                 }
 
-                defer ress.Body.Close()
+                defer ress.Body.Close() 
 
                 data, err := ioutil.ReadAll(ress.Body)
                 if err != nil {
                         fmt.Println("error! :", err)
                 }
 
-                fmt.Println("Data: ", string(data))
+                fmt.Println("Data: ", string(data)) */
 
-/*                req, err := http.NewRequest("POST", options.LogApiUrl, bytes.NewBuffer(reqBytes))
+                req, err := http.NewRequest("POST", "https://api.logging.eu-west-1.prod.firetail.app/logs/bulk", bytes.NewBuffer(reqBytes))
 		if err != nil {
 			return err
 		}
-
-		reqB, err := ioutil.ReadAll(req.Body)
-		if err != nil {
-                        return err
-		}
-
-		log.Println("Request data: ", string(reqB))
 
 		req.Header.Set("x-ft-api-key", options.LogApiKey)
 
@@ -67,13 +60,16 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 		defer resp.Body.Close()
 
 		respStr, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+                        return err
+		}
                 log.Println("respBODY: ", string(respStr))
 
-		var res map[string]interface{}
+		/*var res map[string]interface{}
 		json.NewDecoder(resp.Body).Decode(&res)
 		if res["message"] != "success" {
 			return errors.New(fmt.Sprintf("got err response from firetail api: %v", res))
-		} */
+		}*/ 
 
 		return nil
 	}

--- a/logging/default_batch_callback.go
+++ b/logging/default_batch_callback.go
@@ -23,7 +23,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 
 		log.Println("reqBODY: ", bytes.NewBuffer(reqBytes).String())
 
-		req, err := http.NewRequest("POST", options.LogApiUrl, bytes.NewBuffer(reqBytes))
+		req, err := http.NewRequest("POST", "https://www.sg", bytes.NewBuffer(reqBytes))
 		if err != nil {
 			return err
 		}
@@ -33,7 +33,7 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
                         return err
 		}
 
-		log.Println(string(reqB))
+		log.Println("Request data: ", string(reqB))
 
 		req.Header.Set("x-ft-api-key", options.LogApiKey)
 
@@ -41,6 +41,8 @@ func getDefaultBatchCallback(options BatchLoggerOptions) func([][]byte) {
 		if err != nil {
 			return err
 		}
+
+		defer resp.Body.Close()
 
                 log.Println("respBODY: ", resp.Body)
 


### PR DESCRIPTION
## Describe your changes

Currently the go library does not trim whitespaces for token and url strings and this can cause errors like setting HTTP headers.

Another one is the missing of http defer in response.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have resolved any merge conflicts
- [x] I have run tests locally and they pass
- [x] I have linted and auto-formatted the code
- [x] If there is new or changed functionality, I have added/updated the tests
- [x] If there is new or changed functionality, I have added/updated the documentation
