### PR TITLE
Fix missing resource in logs, fix custom batch callback & make batches configurable

### DIFF
--- a/logging/batch_logger.go
+++ b/logging/batch_logger.go
@@ -25,9 +25,10 @@ type BatchLoggerOptions struct {
 // NewBatchLogger creates a new batchLogger with the provided options
 func NewBatchLogger(options BatchLoggerOptions) *batchLogger {
 	newLogger := &batchLogger{
-		queue:        make(chan *LogEntry),
-		maxBatchSize: options.MaxBatchSize,
-		maxLogAge:    options.MaxLogAge,
+		queue:         make(chan *LogEntry),
+		maxBatchSize:  options.MaxBatchSize,
+		maxLogAge:     options.MaxLogAge,
+		batchCallback: options.BatchCallback,
 	}
 
 	if options.BatchCallback == nil {

--- a/middlewares/http/middleware.go
+++ b/middlewares/http/middleware.go
@@ -53,6 +53,7 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 					Headers:      r.Header,
 					Method:       logging.Method(r.Method),
 					IP:           strings.Split(r.RemoteAddr, ":")[0],
+					Resource:     r.URL.RequestURI(), // We'll fill this in later if we have a router
 				},
 			}
 			if r.TLS != nil {

--- a/middlewares/http/middleware.go
+++ b/middlewares/http/middleware.go
@@ -34,9 +34,17 @@ func GetMiddleware(options *Options) (func(next http.Handler) http.Handler, erro
 	}
 
 	// Create a batchLogger to pass all our log entries to
+	maxBatchSize := 1024 * 512
+	if options.MaxBatchSize > 0 {
+		maxBatchSize = options.MaxBatchSize
+	}
+	maxLogAge := time.Minute
+	if options.MaxLogAge > 0 {
+		maxLogAge = options.MaxLogAge
+	}
 	batchLogger := logging.NewBatchLogger(logging.BatchLoggerOptions{
-		MaxBatchSize:  1024 * 512,
-		MaxLogAge:     time.Minute,
+		MaxBatchSize:  maxBatchSize,
+		MaxLogAge:     maxLogAge,
 		BatchCallback: options.LogBatchCallback,
 		LogApiKey:     options.LogsApiToken,
 		LogApiUrl:     options.LogsApiUrl,

--- a/middlewares/http/options.go
+++ b/middlewares/http/options.go
@@ -34,12 +34,12 @@ type Options struct {
 	// to a file on disk
 	LogBatchCallback func([][]byte)
 
-	// MaxBatchSize is the maximum size of a logging batch which will be sent to the Firetail logging API, in bytes, if the default batch
-	// callback is used. Defaults to 512KiB (524288B).
+	// MaxBatchSize is the maximum size of a logging batch in bytes which will be passed to the LogBatchCallback, or the default callback
+	// if it is used.
 	MaxBatchSize int
 
-	// MaxLogAge is the maximum age of the oldest log in a batch which will be sent to the Firetail logging API, if the default batch
-	// callback is used. Defaults to 1 minute.
+	// MaxLogAge is the maximum age of the oldest log in a batch which will be passed to the LogBatchCallback, or the default callback if
+	// it is used.
 	MaxLogAge time.Duration
 
 	// ErrCallback is an optional callback func which is given an error and a ResponseWriter to which an apropriate response can be written

--- a/middlewares/http/options.go
+++ b/middlewares/http/options.go
@@ -3,6 +3,7 @@ package firetail
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/FireTail-io/firetail-go-lib/logging"
 	"github.com/getkin/kin-openapi/openapi3filter"
@@ -32,6 +33,14 @@ type Options struct {
 	// default callback sends log entries to the Firetail logging API. It may be customised to, for example, additionally log the entries
 	// to a file on disk
 	LogBatchCallback func([][]byte)
+
+	// MaxBatchSize is the maximum size of a logging batch which will be sent to the Firetail logging API, in bytes, if the default batch
+	// callback is used. Defaults to 512KiB (524288B).
+	MaxBatchSize int
+
+	// MaxLogAge is the maximum age of the oldest log in a batch which will be sent to the Firetail logging API, if the default batch
+	// callback is used. Defaults to 1 minute.
+	MaxLogAge time.Duration
 
 	// ErrCallback is an optional callback func which is given an error and a ResponseWriter to which an apropriate response can be written
 	// for the error. This allows you customise the responses given, when for example a request or response fails to validate against the


### PR DESCRIPTION
 - Fixes missing resource in logs
 - Fixes custom batch callback not being used when set
 - Makes max batch size and log age configurable