### PR TITLE
Allow undefined routes

### DIFF
--- a/middlewares/http/options.go
+++ b/middlewares/http/options.go
@@ -64,6 +64,11 @@ type Options struct {
 	// if no openapi spec is provided, then no validation will be performed
 	EnableResponseValidation bool
 
+	// AllowUndefinedRoutes is an optional flag which, if set to true, allows requests to routes which are not defined in the openapi spec
+	// to pass through the middleware without validation. If set to false (default), requests to undefined routes will be rejected and a
+	// 404 response will be returned
+	AllowUndefinedRoutes bool
+
 	// CustomBodyDecoders is a map of Content-Type header values to openapi3 decoders - if the kin-openapi module does not support your
 	// Content-Type by default, you will need to add a custom decoder here
 	CustomBodyDecoders map[string]openapi3filter.BodyDecoder


### PR DESCRIPTION
## Describe your changes

Implements a new option for the middleware - `AllowUndefinedRoutes` - which allows requests to routes not defined in the OpenAPI specification to pass through.

## Issue ticket number and link

https://firetail-io.atlassian.net/browse/FIRE-2897

## Checklist before requesting a review

- [x] I have resolved any merge conflicts
- [x] I have run tests locally and they pass
- [x] I have linted and auto-formatted the code
- [x] If there is new or changed functionality, I have added/updated the tests
- [ ] If there is new or changed functionality, I have added/updated the documentation
